### PR TITLE
Ignore detected block sizes in cdrom provider

### DIFF
--- a/pkg/metadata/providers/provider_cdrom.go
+++ b/pkg/metadata/providers/provider_cdrom.go
@@ -82,6 +82,7 @@ func FindCIs() []string {
 			log.Debugf("failed to open device read-only: %s: %v", dev, err)
 			continue
 		}
+		disk.DefaultBlocks = true
 		fs, err := disk.GetFilesystem(0)
 		if err != nil {
 			log.Debugf("failed to get filesystem on partition 0 for device: %s: %v", dev, err)


### PR DESCRIPTION
A backport of https://github.com/linuxkit/linuxkit/pull/3614

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
